### PR TITLE
Ensure context variables types are not empty

### DIFF
--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -1599,6 +1599,7 @@ public:
      */
     template<typename Type, typename... Args>
     Type & set(Args &&... args) {
+        static_assert(!std::is_empty<Type>::value);
         unset<Type>();
         vars.push_back(variable_data{type_info<Type>::id(), { new Type{std::forward<Args>(args)...}, [](void *instance) { delete static_cast<Type *>(instance); } }});
         return *static_cast<Type *>(vars.back().value.get());


### PR DESCRIPTION
When context variables are empty types, functionalities like `try_ctx` will always return a `nullptr`, which makes impossible to know if the context was set.